### PR TITLE
Account for the recently added `read_exact` method to `Read`.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 //! A basic ZipReader/Writer crate
 
 #![warn(missing_docs)]
+#![feature(read_exact)]
 
 extern crate bzip2;
 extern crate flate2;

--- a/src/read.rs
+++ b/src/read.rs
@@ -195,9 +195,12 @@ fn central_header_to_zip_file<R: Read+io::Seek>(reader: &mut R) -> ZipResult<Zip
     try!(reader.read_u16::<LittleEndian>());
     try!(reader.read_u32::<LittleEndian>());
     let offset = try!(reader.read_u32::<LittleEndian>()) as u64;
-    let file_name_raw = try!(reader.read_exact(file_name_length));
-    let extra_field = try!(reader.read_exact(extra_field_length));
-    let file_comment_raw  = try!(reader.read_exact(file_comment_length));
+    let mut file_name_raw = vec![0; file_name_length];
+    try!(reader.read_exact(&mut file_name_raw));
+    let mut extra_field = vec![0; extra_field_length];
+    try!(reader.read_exact(&mut extra_field));
+    let mut file_comment_raw = vec![0; file_comment_length];
+    try!(reader.read_exact(&mut file_comment_raw));
 
     let file_name = match is_utf8
     {
@@ -206,7 +209,7 @@ fn central_header_to_zip_file<R: Read+io::Seek>(reader: &mut R) -> ZipResult<Zip
     };
     let file_comment = match is_utf8
     {
-        true => String::from_utf8_lossy(&*file_comment_raw).into_owned(),
+        true => String::from_utf8_lossy(&file_comment_raw).into_owned(),
         false => file_comment_raw.from_cp437(),
     };
 

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -34,7 +34,8 @@ impl CentralDirectoryEnd
         let central_directory_size = try!(reader.read_u32::<LittleEndian>());
         let central_directory_offset = try!(reader.read_u32::<LittleEndian>());
         let zip_file_comment_length = try!(reader.read_u16::<LittleEndian>()) as usize;
-        let zip_file_comment = try!(reader.read_exact(zip_file_comment_length));
+        let mut zip_file_comment = vec![0; zip_file_comment_length];
+        try!(reader.read_exact(&mut zip_file_comment));
 
         Ok(CentralDirectoryEnd
            {


### PR DESCRIPTION
This makes zip-rs only compile on nightly rustc, which is a major downside.

How did `read_exact` previously work? Is this not a breaking change? I'm confused.