### PR TITLE
Remove `no-bzip2` feature because it doesn't work as I expected

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,4 +20,3 @@ bzip2 = { version = "0.2", optional = true }
 
 [features]
 default = ["bzip2"]
-no-bzip2 = []


### PR DESCRIPTION
An "oops" PR :)
I realized that `no-bzip2` does not do anything at all, and the right way to get rid of `bzip2` is just saying `zip = { version = "*", default-features = false }` in `Cargo.toml`.