### PR TITLE
Handle data prepended to the zip

### DIFF
--- a/src/spec.rs
+++ b/src/spec.rs
@@ -48,7 +48,7 @@ impl CentralDirectoryEnd
            })
     }
 
-    pub fn find_and_parse<T: Read+io::Seek>(reader: &mut T) -> ZipResult<CentralDirectoryEnd>
+    pub fn find_and_parse<T: Read+io::Seek>(reader: &mut T) -> ZipResult<(CentralDirectoryEnd, u32)>
     {
         let header_size = 22;
         let bytes_between_magic_and_comment_size = header_size - 6;
@@ -66,8 +66,8 @@ impl CentralDirectoryEnd
                 let comment_length = try!(reader.read_u16::<LittleEndian>()) as i64;
                 if file_length - pos - header_size == comment_length
                 {
-                    try!(reader.seek(io::SeekFrom::Start(pos as u64)));
-                    return CentralDirectoryEnd::parse(reader);
+                    let cde_start_pos = try!(reader.seek(io::SeekFrom::Start(pos as u64))) as u32;
+                    return CentralDirectoryEnd::parse(reader).map(|cde| (cde, cde_start_pos));
                 }
             }
             pos -= 1;


### PR DESCRIPTION
The official spec for the Zip format allows arbitrary data to be prepended to the beginning of a Zip file, but doesn't give much help on what that does to the offsets stored in the file headers. This is something that most Zip libraries account for, and I actually have need of this crate supporting it  (gonna use it for self-extracting Zip files).

I looked first to `libarchive` on how to implement this. They handle it by [seeking through the file and looking for what appears to be the first central directory entry](https://github.com/libarchive/libarchive/blob/master/libarchive/archive_read_support_format_zip.c). This is actually unnecessary since we know what position we seek to when we find the start of the central directory end. Thus the offset of the entire archive can be calculated as:

> start of CDE - CD size - CD offset

This PR adds this additional check after reading the footer and before reading anything else, and adjusts all offsets by the above amount.