### PR TITLE
Add data_start property to ZipFile

### DIFF
--- a/src/read.rs
+++ b/src/read.rs
@@ -351,6 +351,11 @@ impl<'a> ZipFile<'a> {
     pub fn crc32(&self) -> u32 {
         self.data.crc32
     }
+
+    /// Get the starting offset of the data of the compressed file
+    pub fn data_start(&self) -> u64 {
+        self.data.data_start
+    }
 }
 
 impl<'a> Read for ZipFile<'a> {


### PR DESCRIPTION
Hey!

In a project I'm working on, I need to be able to access the `data_start` property of a file in a zip file. The use case is: the zip file is stored with no compression, and I am memory mapping each file directly. It works very well. :smile:

It would be greatly appreciated if you could accept this small pull request.