### PR TITLE
Flate2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ Library to support the reading and writing of zip files.
 """
 
 [dependencies]
-flate2 = "0.2"
+flate2 = { git = "https://github.com/alexcrichton/flate2-rs", default-features = false }
 time = "0.1"
 podio = "0.1"
 msdos_time = "0.1"
@@ -22,4 +22,5 @@ bzip2 = { version = "0.3", optional = true }
 walkdir = "1.0"
 
 [features]
-default = ["bzip2"]
+default = ["bzip2", "flate2/default"]
+rust_backend = ["flate2/rust_backend"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ Library to support the reading and writing of zip files.
 """
 
 [dependencies]
-flate2 = { git = "https://github.com/alexcrichton/flate2-rs", default-features = false }
+flate2 = { version = "1.0", default-features = false }
 time = "0.1"
 podio = "0.1"
 msdos_time = "0.1"

--- a/src/read.rs
+++ b/src/read.rs
@@ -8,7 +8,7 @@ use std::io;
 use std::io::prelude::*;
 use std::collections::HashMap;
 use flate2;
-use flate2::FlateReadExt;
+use flate2::read::DeflateDecoder;
 use podio::{ReadPodExt, LittleEndian};
 use types::{ZipFileData, System};
 use cp437::FromCp437;
@@ -237,7 +237,7 @@ impl<R: Read+io::Seek> ZipArchive<R>
             },
             CompressionMethod::Deflated =>
             {
-                let deflate_reader = limit_reader.deflate_decode();
+                let deflate_reader = DeflateDecoder::new(limit_reader);
                 ZipFileReader::Deflated(Crc32Reader::new(
                     deflate_reader,
                     data.crc32))

--- a/src/write.rs
+++ b/src/write.rs
@@ -12,7 +12,6 @@ use std::mem;
 use std::ascii::AsciiExt;
 use time;
 use flate2;
-use flate2::FlateWriteExt;
 use flate2::write::DeflateEncoder;
 use podio::{WritePodExt, LittleEndian};
 use msdos_time::TmMsDosExt;
@@ -341,7 +340,7 @@ impl<W: Write+io::Seek> GenericZipWriter<W>
         *self = match compression
         {
             CompressionMethod::Stored => GenericZipWriter::Storer(bare),
-            CompressionMethod::Deflated => GenericZipWriter::Deflater(bare.deflate_encode(flate2::Compression::Default)),
+            CompressionMethod::Deflated => GenericZipWriter::Deflater(DeflateEncoder::new(bare, flate2::Compression::default())),
             #[cfg(feature = "bzip2")]
             CompressionMethod::Bzip2 => GenericZipWriter::Bzip2(BzEncoder::new(bare, bzip2::Compression::Default)),
             CompressionMethod::Unsupported(..) => return Err(ZipError::UnsupportedArchive("Unsupported compression")),


### PR DESCRIPTION
Updates flate2 to 1.0 and enables use of the rust_backend for flate2.

I ran cargo test with rust_backend turned on (but not without because I can't get default flate2 to compile), seems fine.