### PR TITLE
Made deflate compression into separate feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ Library to support the reading and writing of zip files.
 """
 
 [dependencies]
-flate2 = { version = "1.0", default-features = false, features = ["rust_backend"]}
+flate2 = { version = "1.0", default-features = false, features = ["rust_backend"], optional = true}
 time = "0.1"
 podio = "0.1"
 msdos_time = "0.1"
@@ -22,4 +22,4 @@ bzip2 = { version = "0.3", optional = true }
 walkdir = "1.0"
 
 [features]
-default = ["bzip2"]
+default = ["bzip2", "flate2"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,4 +22,5 @@ bzip2 = { version = "0.3", optional = true }
 walkdir = "1.0"
 
 [features]
-default = ["bzip2", "flate2"]
+deflate = ["flate2"]
+default = ["bzip2", "deflate"]

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -9,7 +9,7 @@ pub enum CompressionMethod
     /// The file is stored (no compression)
     Stored,
     /// The file is Deflated
-    #[cfg(feature = "flate2")]
+    #[cfg(feature = "deflate")]
     Deflated,
     /// File is compressed using BZIP2 algorithm
     #[cfg(feature = "bzip2")]
@@ -23,7 +23,7 @@ impl CompressionMethod {
     pub fn from_u16(val: u16) -> CompressionMethod {
         match val {
             0 => CompressionMethod::Stored,
-            #[cfg(feature = "flate2")]
+            #[cfg(feature = "deflate")]
             8 => CompressionMethod::Deflated,
             #[cfg(feature = "bzip2")]
             12 => CompressionMethod::Bzip2,
@@ -35,7 +35,7 @@ impl CompressionMethod {
     pub fn to_u16(self) -> u16 {
         match self {
             CompressionMethod::Stored => 0,
-            #[cfg(feature = "flate2")]
+            #[cfg(feature = "deflate")]
             CompressionMethod::Deflated => 8,
             #[cfg(feature = "bzip2")]
             CompressionMethod::Bzip2 => 12,
@@ -65,22 +65,22 @@ mod test {
         }
     }
 
-    #[cfg(all(not(feature = "bzip2"), feature = "flate2"))]
+    #[cfg(all(not(feature = "bzip2"), feature = "deflate"))]
     fn methods() -> Vec<CompressionMethod> {
         vec![CompressionMethod::Stored, CompressionMethod::Deflated]
     }
 
-    #[cfg(all(not(feature = "flate2"), feature = "bzip2"))]
+    #[cfg(all(not(feature = "deflate"), feature = "bzip2"))]
     fn methods() -> Vec<CompressionMethod> {
         vec![CompressionMethod::Stored, CompressionMethod::Bzip2]
     }
 
-    #[cfg(all(feature = "bzip2", feature = "flate2"))]
+    #[cfg(all(feature = "bzip2", feature = "deflate"))]
     fn methods() -> Vec<CompressionMethod> {
         vec![CompressionMethod::Stored, CompressionMethod::Deflated, CompressionMethod::Bzip2]
     }
 
-    #[cfg(all(not(feature = "bzip2"), not(feature = "flate2")))]
+    #[cfg(all(not(feature = "bzip2"), not(feature = "deflate")))]
     fn methods() -> Vec<CompressionMethod> {
         vec![CompressionMethod::Stored]
     }

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -9,6 +9,7 @@ pub enum CompressionMethod
     /// The file is stored (no compression)
     Stored,
     /// The file is Deflated
+    #[cfg(feature = "flate2")]
     Deflated,
     /// File is compressed using BZIP2 algorithm
     #[cfg(feature = "bzip2")]
@@ -22,6 +23,7 @@ impl CompressionMethod {
     pub fn from_u16(val: u16) -> CompressionMethod {
         match val {
             0 => CompressionMethod::Stored,
+            #[cfg(feature = "flate2")]
             8 => CompressionMethod::Deflated,
             #[cfg(feature = "bzip2")]
             12 => CompressionMethod::Bzip2,
@@ -33,6 +35,7 @@ impl CompressionMethod {
     pub fn to_u16(self) -> u16 {
         match self {
             CompressionMethod::Stored => 0,
+            #[cfg(feature = "flate2")]
             CompressionMethod::Deflated => 8,
             #[cfg(feature = "bzip2")]
             CompressionMethod::Bzip2 => 12,
@@ -62,14 +65,24 @@ mod test {
         }
     }
 
-    #[cfg(not(feature = "bzip2"))]
+    #[cfg(all(not(feature = "bzip2"), feature = "flate2"))]
     fn methods() -> Vec<CompressionMethod> {
         vec![CompressionMethod::Stored, CompressionMethod::Deflated]
     }
 
-    #[cfg(feature = "bzip2")]
+    #[cfg(all(not(feature = "flate2"), feature = "bzip2"))]
+    fn methods() -> Vec<CompressionMethod> {
+        vec![CompressionMethod::Stored, CompressionMethod::Bzip2]
+    }
+
+    #[cfg(all(feature = "bzip2", feature = "flate2"))]
     fn methods() -> Vec<CompressionMethod> {
         vec![CompressionMethod::Stored, CompressionMethod::Deflated, CompressionMethod::Bzip2]
+    }
+
+    #[cfg(all(not(feature = "bzip2"), not(feature = "flate2")))]
+    fn methods() -> Vec<CompressionMethod> {
+        vec![CompressionMethod::Stored]
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 
 #[cfg(feature = "bzip2")]
 extern crate bzip2;
-#[cfg(feature = "flate2")]
+#[cfg(feature = "deflate")]
 extern crate flate2;
 extern crate msdos_time;
 extern crate podio;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 
 #[cfg(feature = "bzip2")]
 extern crate bzip2;
+#[cfg(feature = "flate2")]
 extern crate flate2;
 extern crate msdos_time;
 extern crate podio;

--- a/src/read.rs
+++ b/src/read.rs
@@ -13,9 +13,9 @@ use types::{ZipFileData, System};
 use cp437::FromCp437;
 use msdos_time::{TmMsDosExt, MsDosDateTime};
 
-#[cfg(feature = "flate2")]
+#[cfg(feature = "deflate")]
 use flate2;
-#[cfg(feature = "flate2")]
+#[cfg(feature = "deflate")]
 use flate2::read::DeflateDecoder;
 
 #[cfg(feature = "bzip2")]
@@ -63,7 +63,7 @@ pub struct ZipArchive<R: Read + io::Seek>
 
 enum ZipFileReader<'a> {
     Stored(Crc32Reader<io::Take<&'a mut Read>>),
-    #[cfg(feature = "flate2")]
+    #[cfg(feature = "deflate")]
     Deflated(Crc32Reader<flate2::read::DeflateDecoder<io::Take<&'a mut Read>>>),
     #[cfg(feature = "bzip2")]
     Bzip2(Crc32Reader<BzDecoder<io::Take<&'a mut Read>>>),
@@ -240,7 +240,7 @@ impl<R: Read+io::Seek> ZipArchive<R>
                     limit_reader,
                     data.crc32))
             },
-            #[cfg(feature = "flate2")]
+            #[cfg(feature = "deflate")]
             CompressionMethod::Deflated =>
             {
                 let deflate_reader = DeflateDecoder::new(limit_reader);
@@ -383,7 +383,7 @@ impl<'a> ZipFile<'a> {
     fn get_reader(&mut self) -> &mut Read {
         match self.reader {
            ZipFileReader::Stored(ref mut r) => r as &mut Read,
-           #[cfg(feature = "flate2")]
+           #[cfg(feature = "deflate")]
            ZipFileReader::Deflated(ref mut r) => r as &mut Read,
            #[cfg(feature = "bzip2")]
            ZipFileReader::Bzip2(ref mut r) => r as &mut Read,

--- a/src/read.rs
+++ b/src/read.rs
@@ -7,12 +7,16 @@ use result::{ZipResult, ZipError};
 use std::io;
 use std::io::prelude::*;
 use std::collections::HashMap;
-use flate2;
-use flate2::read::DeflateDecoder;
+
 use podio::{ReadPodExt, LittleEndian};
 use types::{ZipFileData, System};
 use cp437::FromCp437;
 use msdos_time::{TmMsDosExt, MsDosDateTime};
+
+#[cfg(feature = "flate2")]
+use flate2;
+#[cfg(feature = "flate2")]
+use flate2::read::DeflateDecoder;
 
 #[cfg(feature = "bzip2")]
 use bzip2::read::BzDecoder;
@@ -59,6 +63,7 @@ pub struct ZipArchive<R: Read + io::Seek>
 
 enum ZipFileReader<'a> {
     Stored(Crc32Reader<io::Take<&'a mut Read>>),
+    #[cfg(feature = "flate2")]
     Deflated(Crc32Reader<flate2::read::DeflateDecoder<io::Take<&'a mut Read>>>),
     #[cfg(feature = "bzip2")]
     Bzip2(Crc32Reader<BzDecoder<io::Take<&'a mut Read>>>),
@@ -235,6 +240,7 @@ impl<R: Read+io::Seek> ZipArchive<R>
                     limit_reader,
                     data.crc32))
             },
+            #[cfg(feature = "flate2")]
             CompressionMethod::Deflated =>
             {
                 let deflate_reader = DeflateDecoder::new(limit_reader);
@@ -377,6 +383,7 @@ impl<'a> ZipFile<'a> {
     fn get_reader(&mut self) -> &mut Read {
         match self.reader {
            ZipFileReader::Stored(ref mut r) => r as &mut Read,
+           #[cfg(feature = "flate2")]
            ZipFileReader::Deflated(ref mut r) => r as &mut Read,
            #[cfg(feature = "bzip2")]
            ZipFileReader::Bzip2(ref mut r) => r as &mut Read,

--- a/src/write.rs
+++ b/src/write.rs
@@ -13,9 +13,9 @@ use time;
 use podio::{WritePodExt, LittleEndian};
 use msdos_time::TmMsDosExt;
 
-#[cfg(feature = "flate2")]
+#[cfg(feature = "deflate")]
 use flate2;
-#[cfg(feature = "flate2")]
+#[cfg(feature = "deflate")]
 use flate2::write::DeflateEncoder;
 
 #[cfg(feature = "bzip2")]
@@ -27,7 +27,7 @@ enum GenericZipWriter<W: Write + io::Seek>
 {
     Closed,
     Storer(W),
-    #[cfg(feature = "flate2")]
+    #[cfg(feature = "deflate")]
     Deflater(DeflateEncoder<W>),
     #[cfg(feature = "bzip2")]
     Bzip2(BzEncoder<W>),
@@ -81,7 +81,7 @@ pub struct FileOptions {
 }
 
 impl FileOptions {
-    #[cfg(feature = "flate2")]
+    #[cfg(feature = "deflate")]
     /// Construct a new FileOptions object
     pub fn default() -> FileOptions {
         FileOptions {
@@ -91,7 +91,7 @@ impl FileOptions {
         }
     }
 
-    #[cfg(not(feature = "flate2"))]
+    #[cfg(not(feature = "deflate"))]
     /// Construct a new FileOptions object
     pub fn default() -> FileOptions {
         FileOptions {
@@ -347,7 +347,7 @@ impl<W: Write+io::Seek> GenericZipWriter<W>
         let bare = match mem::replace(self, GenericZipWriter::Closed)
         {
             GenericZipWriter::Storer(w) => w,
-            #[cfg(feature = "flate2")]
+            #[cfg(feature = "deflate")]
             GenericZipWriter::Deflater(w) => try!(w.finish()),
             #[cfg(feature = "bzip2")]
             GenericZipWriter::Bzip2(w) => try!(w.finish()),
@@ -357,7 +357,7 @@ impl<W: Write+io::Seek> GenericZipWriter<W>
         *self = match compression
         {
             CompressionMethod::Stored => GenericZipWriter::Storer(bare),
-            #[cfg(feature = "flate2")]
+            #[cfg(feature = "deflate")]
             CompressionMethod::Deflated => GenericZipWriter::Deflater(DeflateEncoder::new(bare, flate2::Compression::default())),
             #[cfg(feature = "bzip2")]
             CompressionMethod::Bzip2 => GenericZipWriter::Bzip2(BzEncoder::new(bare, bzip2::Compression::Default)),
@@ -370,7 +370,7 @@ impl<W: Write+io::Seek> GenericZipWriter<W>
     fn ref_mut(&mut self) -> Option<&mut Write> {
         match *self {
             GenericZipWriter::Storer(ref mut w) => Some(w as &mut Write),
-            #[cfg(feature = "flate2")]
+            #[cfg(feature = "deflate")]
             GenericZipWriter::Deflater(ref mut w) => Some(w as &mut Write),
             #[cfg(feature = "bzip2")]
             GenericZipWriter::Bzip2(ref mut w) => Some(w as &mut Write),
@@ -399,7 +399,7 @@ impl<W: Write+io::Seek> GenericZipWriter<W>
     fn current_compression(&self) -> Option<CompressionMethod> {
         match *self {
             GenericZipWriter::Storer(..) => Some(CompressionMethod::Stored),
-            #[cfg(feature = "flate2")]
+            #[cfg(feature = "deflate")]
             GenericZipWriter::Deflater(..) => Some(CompressionMethod::Deflated),
             #[cfg(feature = "bzip2")]
             GenericZipWriter::Bzip2(..) => Some(CompressionMethod::Bzip2),

--- a/src/write.rs
+++ b/src/write.rs
@@ -10,10 +10,13 @@ use std::io;
 use std::io::prelude::*;
 use std::mem;
 use time;
-use flate2;
-use flate2::write::DeflateEncoder;
 use podio::{WritePodExt, LittleEndian};
 use msdos_time::TmMsDosExt;
+
+#[cfg(feature = "flate2")]
+use flate2;
+#[cfg(feature = "flate2")]
+use flate2::write::DeflateEncoder;
 
 #[cfg(feature = "bzip2")]
 use bzip2;
@@ -24,6 +27,7 @@ enum GenericZipWriter<W: Write + io::Seek>
 {
     Closed,
     Storer(W),
+    #[cfg(feature = "flate2")]
     Deflater(DeflateEncoder<W>),
     #[cfg(feature = "bzip2")]
     Bzip2(BzEncoder<W>),
@@ -77,6 +81,7 @@ pub struct FileOptions {
 }
 
 impl FileOptions {
+    #[cfg(feature = "flate2")]
     /// Construct a new FileOptions object
     pub fn default() -> FileOptions {
         FileOptions {
@@ -86,9 +91,21 @@ impl FileOptions {
         }
     }
 
+    #[cfg(not(feature = "flate2"))]
+    /// Construct a new FileOptions object
+    pub fn default() -> FileOptions {
+        FileOptions {
+            compression_method: CompressionMethod::Stored,
+            last_modified_time: time::now(),
+            permissions: None,
+        }
+    }
+
     /// Set the compression method for the new file
     ///
-    /// The default is `CompressionMethod::Deflated`
+    /// The default is `CompressionMethod::Deflated`. If the deflate compression feature is
+    /// disabled, `CompressionMethod::Stored` becomes the default.
+    /// otherwise.
     pub fn compression_method(mut self, method: CompressionMethod) -> FileOptions {
         self.compression_method = method;
         self
@@ -330,6 +347,7 @@ impl<W: Write+io::Seek> GenericZipWriter<W>
         let bare = match mem::replace(self, GenericZipWriter::Closed)
         {
             GenericZipWriter::Storer(w) => w,
+            #[cfg(feature = "flate2")]
             GenericZipWriter::Deflater(w) => try!(w.finish()),
             #[cfg(feature = "bzip2")]
             GenericZipWriter::Bzip2(w) => try!(w.finish()),
@@ -339,6 +357,7 @@ impl<W: Write+io::Seek> GenericZipWriter<W>
         *self = match compression
         {
             CompressionMethod::Stored => GenericZipWriter::Storer(bare),
+            #[cfg(feature = "flate2")]
             CompressionMethod::Deflated => GenericZipWriter::Deflater(DeflateEncoder::new(bare, flate2::Compression::default())),
             #[cfg(feature = "bzip2")]
             CompressionMethod::Bzip2 => GenericZipWriter::Bzip2(BzEncoder::new(bare, bzip2::Compression::Default)),
@@ -351,6 +370,7 @@ impl<W: Write+io::Seek> GenericZipWriter<W>
     fn ref_mut(&mut self) -> Option<&mut Write> {
         match *self {
             GenericZipWriter::Storer(ref mut w) => Some(w as &mut Write),
+            #[cfg(feature = "flate2")]
             GenericZipWriter::Deflater(ref mut w) => Some(w as &mut Write),
             #[cfg(feature = "bzip2")]
             GenericZipWriter::Bzip2(ref mut w) => Some(w as &mut Write),
@@ -379,6 +399,7 @@ impl<W: Write+io::Seek> GenericZipWriter<W>
     fn current_compression(&self) -> Option<CompressionMethod> {
         match *self {
             GenericZipWriter::Storer(..) => Some(CompressionMethod::Stored),
+            #[cfg(feature = "flate2")]
             GenericZipWriter::Deflater(..) => Some(CompressionMethod::Deflated),
             #[cfg(feature = "bzip2")]
             GenericZipWriter::Bzip2(..) => Some(CompressionMethod::Bzip2),


### PR DESCRIPTION
Though likely not intended by the format's designers, my application is using ZIP files without any compression at all (the files are themselves compressed) and is targeting a platform without a C compiler (at least not one Rust can find at the moment). The most straightforward way to this goal was to disable both bzip2 and deflate compression. The latter required creating a feature gate, hence this PR.

I started this on an older crates.io version of the library, and I now see that perhaps the miniz_oxide dependency change has obsoleted this problem. If you see no other reason for this separate feature gate, feel free to just close this PR.
  