### PR TITLE
Fix compatibility with Rust <1.23

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: rust
 
 rust:
     - stable
+    - 1.20.0
 
 sudo: false
 

--- a/src/write.rs
+++ b/src/write.rs
@@ -19,6 +19,8 @@ use msdos_time::TmMsDosExt;
 use bzip2;
 #[cfg(feature = "bzip2")]
 use bzip2::write::BzEncoder;
+#[allow(unused_imports)] // Rust <1.23 compat
+use std::ascii::AsciiExt;
 
 enum GenericZipWriter<W: Write + io::Seek>
 {


### PR DESCRIPTION
The commit bbb279286a76a60cf24462e6be20504c16d01f5b broke compatibility for Rust <1.23 (released just 4 days ago) in a minor version release.

As mentioned in the [release notes](https://blog.rust-lang.org/2018/01/04/Rust-1.23.html#library-stabilizations), the import should still be used for backwards compatibility with the `allow(unused_imports)` attribute.

I did a quick test and found that the "fixed" version builds down to Rust 1.20 (below the podio dependency won't build anymore), so I added that version to Travis. May I suggest to declare the min supported Rust version in the README file?

Thanks for your work on the crate! :)
  