### PR TITLE
Fix `walkdir` broken link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,6 @@ Examples
 
 See the [examples directory](examples) for:
    * How to write a file to a zip.
-   * how to write a directory of files to a zip (using [walkdir](/BurntSushi/walkdir)).
+   * how to write a directory of files to a zip (using [walkdir](https://github.com/BurntSushi/walkdir)).
    * How to extract a zip file.
    * How to extract a single file from a zip.


### PR DESCRIPTION
You used a relative path to reference `walkdir` repository, but github starts at your repository URL.

- Old broken link: `https://github.com/mvdnes/zip-rs/blob/master/BurntSushi/walkdir`;
- New link: `https://github.com/BurntSushi/walkdir`.