### PR TITLE
 Fix file name sanitization for zips with OS incompatible path separators

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -63,7 +63,7 @@ pub struct ZipFileData
 
 impl ZipFileData {
     pub fn file_name_sanitized(&self) -> ::std::path::PathBuf {
-        let no_null_filename: String = match self.file_name.find('\0') {
+        let no_null_filename = match self.file_name.find('\0') {
             Some(index) => &self.file_name[0..index],
             None => &self.file_name,
         }.to_string();

--- a/src/types.rs
+++ b/src/types.rs
@@ -63,12 +63,23 @@ pub struct ZipFileData
 
 impl ZipFileData {
     pub fn file_name_sanitized(&self) -> ::std::path::PathBuf {
-        let no_null_filename = match self.file_name.find('\0') {
+        let no_null_filename: String = match self.file_name.find('\0') {
             Some(index) => &self.file_name[0..index],
             None => &self.file_name,
-        };
+        }.to_string();
 
-        ::std::path::Path::new(no_null_filename)
+        // zip files can contain both / and \ as separators regardless of the OS
+        // and as we want to return a sanitized PathBuf that only supports the
+        // OS separator let's convert incompatible separators to compatible ones
+        let separator = ::std::path::MAIN_SEPARATOR;
+        let opposite_separator = match separator {
+            '/' => '\\',
+            '\\' | _ => '/',
+        };
+        let filename =
+            no_null_filename.replace(&opposite_separator.to_string(), &separator.to_string());
+
+        ::std::path::Path::new(&filename)
             .components()
             .filter(|component| match *component {
                 ::std::path::Component::Normal(..) => true,


### PR DESCRIPTION
Ran into an issue with .zip files created from PowerShell `Compress-Archive` and a few other sources that contained "\" as path separator instead of "/" from which `sanitized_name()` then returned incorrect PathBuf objects on Linux & Mac where entire path was a single long component causing issues in user code.

So Zip files can contain both / and \ as separators regardless of the OS, and as we want to return a sanitized PathBuf that only supports the OS separator let's convert incompatible separators to compatible ones.

If one doesn't do this then PathBufs will be returned that can have entire paths in the file name such as "src\\lib.rs" on Linux/Mac, instead of "srv", "/", "lib.rs" as 3 separate components.