### PR TITLE
expose Zip file specifications

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ pub use read::ZipArchive;
 pub use write::ZipWriter;
 pub use compression::CompressionMethod;
 
-mod spec;
+pub mod spec;
 mod crc32;
 mod types;
 pub mod read;

--- a/src/result.rs
+++ b/src/result.rs
@@ -27,7 +27,7 @@ pub enum ZipError
 
 impl ZipError
 {
-    fn detail(&self) -> ::std::borrow::Cow<str>
+    pub fn detail(&self) -> ::std::borrow::Cow<str>
     {
         use std::error::Error;
 

--- a/src/result.rs
+++ b/src/result.rs
@@ -27,6 +27,7 @@ pub enum ZipError
 
 impl ZipError
 {
+    /// returns a description of the error
     pub fn detail(&self) -> ::std::borrow::Cow<str>
     {
         use std::error::Error;


### PR DESCRIPTION
Hi,

I was wondering if you are willing to expose the Zip file specification to users of your crate.

I'm using it in my project and it would be very helpful to be able to use those directly from your crate instead of reimplementing.

I made this pull request exposing them, and adding some documentation.

Let me know what you think about it. 

I'm very very new to Rust so if you have any suggestion on how to improve this PR, please let me know also

Thanks

Marco