### PR TITLE
Replace `try!` macros with `?` operator calls

### DIFF
--- a/examples/write_sample.rs
+++ b/examples/write_sample.rs
@@ -33,16 +33,16 @@ fn doit(filename: &str) -> zip::result::ZipResult<()>
 
     let mut zip = zip::ZipWriter::new(file);
 
-    try!(zip.add_directory("test/", FileOptions::default()));
+    zip.add_directory("test/", FileOptions::default())?;
 
     let options = FileOptions::default().compression_method(zip::CompressionMethod::Stored).unix_permissions(0o755);
-    try!(zip.start_file("test/☃.txt", options));
-    try!(zip.write_all(b"Hello, World!\n"));
+    zip.start_file("test/☃.txt", options)?;
+    zip.write_all(b"Hello, World!\n")?;
 
-    try!(zip.start_file("test/lorem_ipsum.txt", FileOptions::default()));
-    try!(zip.write_all(LOREM_IPSUM));
+    zip.start_file("test/lorem_ipsum.txt", FileOptions::default())?;
+    zip.write_all(LOREM_IPSUM)?;
 
-    try!(zip.finish());
+    zip.finish()?;
     Ok(())
 }
 


### PR DESCRIPTION
The `?` operator exists since Rust version 1.13.0 and has since become the
standard and recommended variant over the `try!` macro (see
https://doc.rust-lang.org/std/macro.try.html where it is explicitly mentioned to
use the `?` operator instead of the `try!` macro).

I think it is especially useful to replace the `try!` usages throughout the
examples (since new users might not be familiar with the `try!` macro at all).