### PR TITLE
Add `chrono` as an optional crate to replace `time` and `msdos_time`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,11 @@ Library to support the reading and writing of zip files.
 """
 
 [dependencies]
+chrono = { version = "0.4", optional = true }
 flate2 = { version = "1.0", default-features = false, optional = true }
-time = "0.1"
+time = { version = "0.1", optional = true }
 podio = "0.1"
-msdos_time = "0.1"
+msdos_time = { version = "0.1", optional = true }
 bzip2 = { version = "0.3", optional = true }
 
 [dev-dependencies]
@@ -25,4 +26,4 @@ walkdir = "1.0"
 deflate = ["flate2", "flate2/rust_backend"]
 deflate-miniz = ["flate2", "flate2/miniz-sys"]
 deflate-zlib = ["flate2", "flate2/zlib"]
-default = ["bzip2", "deflate"]
+default = ["bzip2", "deflate", "time", "msdos_time"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,10 +4,14 @@
 
 #[cfg(feature = "bzip2")]
 extern crate bzip2;
+#[cfg(feature = "chrono")]
+extern crate chrono;
 #[cfg(feature = "flate2")]
 extern crate flate2;
+#[cfg(not(feature = "chrono"))]
 extern crate msdos_time;
 extern crate podio;
+#[cfg(not(feature = "chrono"))]
 extern crate time;
 
 pub use read::ZipArchive;

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,5 +1,8 @@
 //! Types that specify what is contained in a ZIP.
 
+#[cfg(feature = "chrono")]
+use chrono::NaiveDateTime;
+#[cfg(not(feature = "chrono"))]
 use time;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -40,6 +43,9 @@ pub struct ZipFileData
     /// Compression method used to store the file
     pub compression_method: ::compression::CompressionMethod,
     /// Last modified time. This will only have a 2 second precision.
+    #[cfg(feature = "chrono")]
+    pub last_modified_time: NaiveDateTime,
+    #[cfg(not(feature = "chrono"))]
     pub last_modified_time: time::Tm,
     /// CRC32 checksum
     pub crc32: u32,
@@ -120,6 +126,9 @@ mod test {
             version_made_by: 0,
             encrypted: false,
             compression_method: ::compression::CompressionMethod::Stored,
+            #[cfg(feature = "chrono")]
+            last_modified_time: NaiveDateTime::from_timestamp(0, 0),
+            #[cfg(not(feature = "chrono"))]
             last_modified_time: time::empty_tm(),
             crc32: 0,
             compressed_size: 0,


### PR DESCRIPTION
The `time` crate is no longer actively maintained.  It lists `chrono` as an alternative, and looking at the 'Recent' statistics on crates.io `chrono`, seems to be about as popular as `time`.  For all the `chrono` users out there it would be nice, not to have to convert between `time`'s structs and `chrono`'s structs whenever working with zip files.

The disadvantage of the PR is that it makes the code base quite a bit more complex with a lot of `#[cfg]` attributes.  I am especially unhappy with the added nested code blocks in `read.rs` required to guard multiple code lines with a single `#[cfg]` attribute, but I could not find a better solution.  The `cfg!` macro does not help, because both code paths must be valid with any set of feature flags.  This does not work out, because the one branch needs `chrono` types (which are only available with the 'chrono' feature flag) and the other ones requires `time` types (which are only available if the 'chrono' feature flag has __not__ been set).

Finally I pulled in the `#[cfg]` attribute for `write::FileOptions::default`, so that we don't need to define the whole function twice.  Technically this does not directly have anything to do with the `chrono` addition, but made my life a bit easier since I didn't have to add the guarded definitions of `last_modified_time` to both versions of the method.