### PR TITLE
File info perf improvements

### DIFF
--- a/examples/file_info.rs
+++ b/examples/file_info.rs
@@ -1,6 +1,7 @@
 extern crate zip;
 
 use std::fs;
+use std::io::BufReader;
 
 fn main() {
     std::process::exit(real_main());
@@ -14,8 +15,9 @@ fn real_main() -> i32 {
     }
     let fname = std::path::Path::new(&*args[1]);
     let file = fs::File::open(&fname).unwrap();
+    let reader = BufReader::new(file);
 
-    let mut archive = zip::ZipArchive::new(file).unwrap();
+    let mut archive = zip::ZipArchive::new(reader).unwrap();
 
     for i in 0..archive.len() {
         let file = archive.by_index(i).unwrap();

--- a/src/write.rs
+++ b/src/write.rs
@@ -1,7 +1,7 @@
 //! Structs for creating a new zip archive
 
 use compression::CompressionMethod;
-use types::{ZipFileData, System, DEFAULT_VERSION};
+use types::{ZipFileData, System, DEFAULT_VERSION, DateTime};
 use spec;
 use crc32;
 use result::{ZipResult, ZipError};
@@ -11,7 +11,6 @@ use std::io::prelude::*;
 use std::mem;
 use time;
 use podio::{WritePodExt, LittleEndian};
-use msdos_time::TmMsDosExt;
 
 #[cfg(feature = "flate2")]
 use flate2;
@@ -204,7 +203,7 @@ impl<W: Write+io::Seek> ZipWriter<W>
                 version_made_by: DEFAULT_VERSION,
                 encrypted: false,
                 compression_method: options.compression_method,
-                last_modified_time: options.last_modified_time,
+                last_modified_time: DateTime::Tm(options.last_modified_time),
                 crc32: 0,
                 compressed_size: 0,
                 uncompressed_size: 0,


### PR DESCRIPTION
Hi!

I'm using the `zip` crate to load rather big (50+MB, 10K+ files) zip archives, identify a handful of files that are of interest to me, and extract those.

While benchmarking my application, I noticed that a large amount of time (~40%) is spent in the `ZipArchive::new` method.

In order to improve the performance of this operation, I have implemented changes to defer two relatively costly operations:

- Deferring the parsing of the local file header until `ZipArchive::by_index` is called helps with the efficiency of `BufReader`, since it eliminates 2 seek operations per file entry which used to invalidate the read buffer and force a syscall
- Deferring the conversion of the MSDOS datetime to `time::Tz` until `ZipFile::last_modified` is called, since `Tm::to_timespec` invokes a syscall (at least on my OSX machine) every time it is called (once per file entry)

Implementing these two changes reduced the time taken for the `file_info` example from 380-400ms down to 210-230ms (w/o using `BufReader` the initial runtime was ~650ms).

The two optimisations are largely independent, so let me know if you'd like me to split this into multiple PRs!

For reference, an `unzip -l` on the same file takes about 140ms, so I'm planning to investigate further and see what other improvements can be made.

Let me know what you think!