### PR TITLE
Read files inside ZipArchive lazily

### DIFF
--- a/src/read.rs
+++ b/src/read.rs
@@ -451,10 +451,11 @@ fn read_files_till<'a, R>(
     last_central_header_end: &mut u64,
     predicate: ReadFilesTillPredicate,
 ) -> ZipResult<&'a mut ZipFileData> where R: Read + io::Seek {
+    if let Err(_) = reader.seek(io::SeekFrom::Start(*last_central_header_end)) {
+        return Err(ZipError::InvalidArchive("Could not seek to start of central file header"));
+    }
+
     for file_number in files.len()..number_of_files {
-        if let Err(_) = reader.seek(io::SeekFrom::Start(*last_central_header_end)) {
-            return Err(ZipError::InvalidArchive("Could not seek to start of central file header"));
-        }
         let file = central_header_to_zip_file(&mut reader, offset, last_central_header_end)?;
 
         let matches = match predicate {


### PR DESCRIPTION
Before this change, the entire central directory would be parsed to extract
the details of all files in the archive up-front.

With this change, the central directory is parsed on-demand - only enough
headers are parsed till the caller finds the file it wanted.

This speeds up callers who only wish to pick out specific files from
the archive, especially for archives with many thousands of files or
archives hosted on slow storage media. In the case where the caller *did* want
every file in the archive, this performs no worse than the original code.