### PR TITLE
Make traits for zip files

### DIFF
--- a/examples/extract.rs
+++ b/examples/extract.rs
@@ -2,6 +2,7 @@ extern crate zip;
 
 use std::io;
 use std::fs;
+use zip::ZipArchiveRead;
 
 fn main() {
     std::process::exit(real_main());

--- a/examples/extract_lorem.rs
+++ b/examples/extract_lorem.rs
@@ -1,4 +1,5 @@
 use std::io::prelude::*;
+use zip::ZipArchiveRead;
 
 extern crate zip;
 

--- a/examples/file_info.rs
+++ b/examples/file_info.rs
@@ -2,6 +2,7 @@ extern crate zip;
 
 use std::fs;
 use std::io::BufReader;
+use zip::ZipArchiveRead;
 
 fn main() {
     std::process::exit(real_main());

--- a/examples/write_dir.rs
+++ b/examples/write_dir.rs
@@ -4,7 +4,7 @@ extern crate walkdir;
 use std::io::prelude::*;
 use std::io::{Write, Seek};
 use std::iter::Iterator;
-use zip::write::FileOptions;
+use zip::write::{FileOptions, ZipArchiveWrite};
 use zip::result::ZipError;
 
 use walkdir::{WalkDir, DirEntry};

--- a/examples/write_sample.rs
+++ b/examples/write_sample.rs
@@ -1,5 +1,5 @@
 use std::io::prelude::*;
-use zip::write::FileOptions;
+use zip::write::{FileOptions, ZipArchiveWrite};
 
 extern crate zip;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ extern crate time;
 pub use read::ZipArchive;
 pub use read::ZipArchiveRead;
 pub use write::ZipWriter;
+pub use write::ZipArchiveWrite;
 pub use compression::CompressionMethod;
 pub use types::DateTime;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ extern crate podio;
 extern crate time;
 
 pub use read::ZipArchive;
+pub use read::ZipArchiveRead;
 pub use write::ZipWriter;
 pub use compression::CompressionMethod;
 pub use types::DateTime;

--- a/src/read.rs
+++ b/src/read.rs
@@ -27,6 +27,7 @@ mod ffi {
 /// Wrapper for reading the contents of a ZIP file.
 ///
 /// ```
+/// use zip::ZipArchiveRead;
 /// fn doit() -> zip::result::ZipResult<()>
 /// {
 ///     use std::io::prelude::*;
@@ -58,6 +59,40 @@ pub struct ZipArchive<R: Read + io::Seek>
     names_map: HashMap<String, usize>,
     offset: u64,
     comment: Vec<u8>,
+}
+
+
+/// Trait describing functionality of a ZIP file
+pub trait ZipArchiveRead {
+    /// Number of files contained in this zip.
+    ///
+    /// ```
+    /// use zip::ZipArchiveRead;
+    /// fn iter() {
+    ///     let mut zip = zip::ZipArchive::new(std::io::Cursor::new(vec![])).unwrap();
+    ///
+    ///     for i in 0..zip.len() {
+    ///         let mut file = zip.by_index(i).unwrap();
+    ///         // Do something with file i
+    ///     }
+    /// }
+    /// ```
+    fn len(&self) -> usize;
+
+    /// Get the offset from the beginning of the underlying reader that this zip begins at, in bytes.
+    ///
+    /// Normally this value is zero, but if the zip has arbitrary data prepended to it, then this value will be the size
+    /// of that prepended data.
+    fn offset(&self) -> u64;
+
+    /// Search for a file entry by name
+    fn by_name<'a>(&'a mut self, name: &str) -> ZipResult<ZipFile<'a>>;
+
+    /// Get a contained file by index
+    fn by_index<'a>(&'a mut self, file_number: usize) -> ZipResult<ZipFile<'a>>;
+
+    /// Get the comment field for this archive
+    fn comment<'a>(&'a self) -> &Vec<u8>;
 }
 
 enum ZipFileReader<'a> {
@@ -226,33 +261,26 @@ impl<R: Read+io::Seek> ZipArchive<R>
         })
     }
 
-    /// Number of files contained in this zip.
+    /// Unwrap and return the inner reader object
     ///
-    /// ```
-    /// fn iter() {
-    ///     let mut zip = zip::ZipArchive::new(std::io::Cursor::new(vec![])).unwrap();
-    ///
-    ///     for i in 0..zip.len() {
-    ///         let mut file = zip.by_index(i).unwrap();
-    ///         // Do something with file i
-    ///     }
-    /// }
-    /// ```
-    pub fn len(&self) -> usize
+    /// The position of the reader is undefined.
+    pub fn into_inner(self) -> R
+    {
+        self.reader
+    }
+}
+
+impl <R: Read+io::Seek> ZipArchiveRead for ZipArchive<R> {
+    fn len(&self) -> usize
     {
         self.files.len()
     }
 
-    /// Get the offset from the beginning of the underlying reader that this zip begins at, in bytes.
-    ///
-    /// Normally this value is zero, but if the zip has arbitrary data prepended to it, then this value will be the size
-    /// of that prepended data.
-    pub fn offset(&self) -> u64 {
+    fn offset(&self) -> u64 {
         self.offset
     }
 
-    /// Search for a file entry by name
-    pub fn by_name<'a>(&'a mut self, name: &str) -> ZipResult<ZipFile<'a>>
+    fn by_name<'a>(&'a mut self, name: &str) -> ZipResult<ZipFile<'a>>
     {
         let index = match self.names_map.get(name) {
             Some(index) => *index,
@@ -261,8 +289,7 @@ impl<R: Read+io::Seek> ZipArchive<R>
         self.by_index(index)
     }
 
-    /// Get a contained file by index
-    pub fn by_index<'a>(&'a mut self, file_number: usize) -> ZipResult<ZipFile<'a>>
+    fn by_index<'a>(&'a mut self, file_number: usize) -> ZipResult<ZipFile<'a>>
     {
         if file_number >= self.files.len() { return Err(ZipError::FileNotFound); }
         let ref mut data = self.files[file_number];
@@ -291,13 +318,8 @@ impl<R: Read+io::Seek> ZipArchive<R>
 
         Ok(ZipFile { reader: make_reader(data.compression_method, data.crc32, limit_reader)?, data: Cow::Borrowed(data) })
     }
-
-    /// Unwrap and return the inner reader object
-    ///
-    /// The position of the reader is undefined.
-    pub fn into_inner(self) -> R
-    {
-        self.reader
+    fn comment<'a>(&'a self) -> &Vec<u8> {
+        &self.comment
     }
 }
 
@@ -646,7 +668,7 @@ mod test {
     #[test]
     fn zip64_with_leading_junk() {
         use std::io;
-        use super::ZipArchive;
+        use super::{ZipArchive, ZipArchiveRead};
 
         let mut v = Vec::new();
         v.extend_from_slice(include_bytes!("../tests/data/zip64_demo.zip"));
@@ -657,12 +679,12 @@ mod test {
     #[test]
     fn zip_comment() {
         use std::io;
-        use super::ZipArchive;
+        use super::{ZipArchive, ZipArchiveRead};
 
         let mut v = Vec::new();
         v.extend_from_slice(include_bytes!("../tests/data/mimetype.zip"));
         let reader = ZipArchive::new(io::Cursor::new(v)).unwrap();
-        assert!(reader.comment == b"zip-rs");
+        assert!(reader.comment() == b"zip-rs");
     }
 
     #[test]
@@ -684,7 +706,7 @@ mod test {
     #[test]
     fn zip_clone() {
         use std::io::{self, Read};
-        use super::ZipArchive;
+        use super::{ZipArchive, ZipArchiveRead};
 
         let mut v = Vec::new();
         v.extend_from_slice(include_bytes!("../tests/data/mimetype.zip"));

--- a/src/read.rs
+++ b/src/read.rs
@@ -64,6 +64,8 @@ pub struct ZipArchive<R: Read + io::Seek>
 
 /// Trait describing functionality of a ZIP file
 pub trait ZipArchiveRead {
+    /// Underlying reader type
+    type Reader;
     /// Number of files contained in this zip.
     ///
     /// ```
@@ -93,6 +95,11 @@ pub trait ZipArchiveRead {
 
     /// Get the comment field for this archive
     fn comment<'a>(&'a self) -> &Vec<u8>;
+
+    /// Unwrap and return the inner reader object
+    ///
+    /// The position of the reader is undefined.
+    fn into_inner(self) -> Self::Reader;
 }
 
 enum ZipFileReader<'a> {
@@ -261,16 +268,10 @@ impl<R: Read+io::Seek> ZipArchive<R>
         })
     }
 
-    /// Unwrap and return the inner reader object
-    ///
-    /// The position of the reader is undefined.
-    pub fn into_inner(self) -> R
-    {
-        self.reader
-    }
 }
 
 impl <R: Read+io::Seek> ZipArchiveRead for ZipArchive<R> {
+    type Reader = R;
     fn len(&self) -> usize
     {
         self.files.len()
@@ -320,6 +321,11 @@ impl <R: Read+io::Seek> ZipArchiveRead for ZipArchive<R> {
     }
     fn comment<'a>(&'a self) -> &Vec<u8> {
         &self.comment
+    }
+
+    fn into_inner(self) -> R
+    {
+        self.reader
     }
 }
 

--- a/tests/end_to_end.rs
+++ b/tests/end_to_end.rs
@@ -2,6 +2,7 @@ extern crate zip;
 
 use std::io::prelude::*;
 use zip::write::FileOptions;
+use zip::ZipArchiveRead;
 use std::io::Cursor;
 
 // This test asserts that after creating a zip file, then reading its contents back out,

--- a/tests/end_to_end.rs
+++ b/tests/end_to_end.rs
@@ -2,7 +2,7 @@ extern crate zip;
 
 use std::io::prelude::*;
 use zip::write::FileOptions;
-use zip::ZipArchiveRead;
+use zip::{ZipArchiveRead, ZipArchiveWrite};
 use std::io::Cursor;
 
 // This test asserts that after creating a zip file, then reading its contents back out,

--- a/tests/zip64_large.rs
+++ b/tests/zip64_large.rs
@@ -190,6 +190,7 @@ impl Read for Zip64File {
 
 #[test]
 fn zip64_large() {
+    use zip::ZipArchiveRead;
     let zipfile = Zip64File::new();
     let mut archive = zip::ZipArchive::new(zipfile).unwrap();
     let mut buf = [0u8; 32];


### PR DESCRIPTION
It's currently very difficult to have a list or struct of ZipArchives with different underlying reader types (eg. some file-backed, some memory-backed). This introduces new traits for the structs that have generic arguments. 

Eg, old:
```rust
struct MyStructThatHasAZip<T> {
   zip : Box<ZipArchive<T>>;
}
```
vs new:
```rust
struct MyStructThatHasAZip {
   zip : Box<ZipArchiveRead>;
}
```

 **This would be a breaking API change since any method use would require importing the relevant trait instead of the archive type. This is a rust limitation/"feature"**

Possible improvements: 
 - Make ZipWriter implement ZipArchiveRead to allow reading back data