### PR TITLE
Fix bounds check in DateTime::from_time

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -110,7 +110,7 @@ impl DateTime {
     ///
     /// Returns `Err` when this object is out of bounds
     pub fn from_time(tm: ::time::Tm) -> Result<DateTime, ()> {
-        if tm.tm_year >= 1980 && tm.tm_year <= 2107
+        if tm.tm_year >= 80 && tm.tm_year <= 207
             && tm.tm_mon >= 1 && tm.tm_mon <= 31
             && tm.tm_mday >= 1 && tm.tm_mday <= 31
             && tm.tm_hour >= 0 && tm.tm_hour <= 23


### PR DESCRIPTION
The bounds check in the DateTime::from_time function did not use the correct bounds for checking the year.

The new bounds are [80, 207], which accounts for the tm_year field storing the years since 1900.