### PR TITLE
Add basic iterator/find support

### DIFF
--- a/src/cp437.rs
+++ b/src/cp437.rs
@@ -170,7 +170,6 @@ fn to_char(input: u8) -> char
         0xfd => 0x00b2,
         0xfe => 0x25a0,
         0xff => 0x00a0,
-        _ => unreachable!(),
     };
     ::std::char::from_u32(output).unwrap()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,16 +11,16 @@ extern crate podio;
 #[cfg(feature = "time")]
 extern crate time;
 
-pub use read::ZipArchive;
-pub use write::ZipWriter;
 pub use compression::CompressionMethod;
-pub use types::DateTime;
+pub use read::ZipArchive;
+pub use types::{DateTime, ZipFileId};
+pub use write::ZipWriter;
 
-mod spec;
-mod crc32;
-mod types;
-pub mod read;
 mod compression;
-pub mod write;
 mod cp437;
+mod crc32;
+pub mod read;
 pub mod result;
+mod spec;
+mod types;
+pub mod write;

--- a/src/types.rs
+++ b/src/types.rs
@@ -225,6 +225,32 @@ pub struct ZipFileData
     pub external_attributes: u32,
 }
 
+/// Helper struct for slightly more idiomatic interaction
+/// with archives
+pub struct ZipFileId {
+    data_start: u64,
+    header_start: u64,
+    crc32: u32,
+}
+
+impl From<&'_ ZipFileData> for ZipFileId {
+    fn from(other: &'_ ZipFileData) -> Self {
+        ZipFileId {
+            data_start: other.data_start,
+            header_start: other.header_start,
+            crc32: other.crc32,
+        }
+    }
+}
+
+impl PartialEq<ZipFileData> for ZipFileId {
+    fn eq(&self, fd: &ZipFileData) -> bool {
+        self.header_start == fd.header_start
+            && self.data_start == fd.data_start
+            && self.crc32 == fd.crc32
+    }
+}
+
 impl ZipFileData {
     pub fn file_name_sanitized(&self) -> ::std::path::PathBuf {
         let no_null_filename = match self.file_name.find('\0') {


### PR DESCRIPTION
ZipArchive is a bit cumbersome to use when you are consuming archives with unknown/variable contents, so this PR exposes 3 helper methods on ZipArchive to make it slightly easier to consume such content.

* `iter_files()` - Returns an iterator over the internal vector of ZipFileData, which allows people to use all of the standard iterator goodies they are used to
* `by_id()` - As with the existing by_name/by_index, returns the ZipFile if that id exists. The id can be converted from a &ZipFileData and is unique (not name based)
* `find()` - While iter_files().map() + by_id() or iter_files().position() + by_index() can be used to find a file matching criteria, they are a bit cumbersome to use due to the borrow checker since iter_files() is an immutable borrow and all of by_ methods are mutable, so `find` just wraps the most common case of "get me the file that matches this predicate, if it exists"