### PR TITLE
add support for concurrently read on ZipFile level

### DIFF
--- a/examples/extract.rs
+++ b/examples/extract.rs
@@ -2,6 +2,7 @@ extern crate zip;
 
 use std::io;
 use std::fs;
+use zip::read::ZipFileEntry;
 
 fn main() {
     std::process::exit(real_main());

--- a/examples/file_info.rs
+++ b/examples/file_info.rs
@@ -2,6 +2,7 @@ extern crate zip;
 
 use std::fs;
 use std::io::BufReader;
+use zip::read::ZipFileEntry;
 
 fn main() {
     std::process::exit(real_main());

--- a/examples/stdin_info.rs
+++ b/examples/stdin_info.rs
@@ -1,6 +1,7 @@
 extern crate zip;
 
 use std::io::{self, Read};
+use zip::read::ZipFileEntry;
 
 fn main() {
     std::process::exit(real_main());

--- a/src/crc32.rs
+++ b/src/crc32.rs
@@ -31,6 +31,18 @@ impl<R> Crc32Reader<R>
         self.check == self.hasher.clone().finalize()
     }
 
+    pub fn get_ref(&self) -> &R {
+        &self.inner
+    }
+
+    pub fn replace_inner<S>(&self, inner: S) -> Crc32Reader<S> {
+        Crc32Reader {
+            inner,
+            hasher: self.hasher.clone(),
+            check: self.check,
+        }
+    }
+
     pub fn into_inner(self) -> R {
         self.inner
     }

--- a/src/result.rs
+++ b/src/result.rs
@@ -23,6 +23,9 @@ pub enum ZipError
 
     /// The requested file could not be found in the archive
     FileNotFound,
+
+    /// The reader operation is probably unsupported
+    UnsupportedReaderOperation(&'static str),
 }
 
 impl ZipError
@@ -36,7 +39,7 @@ impl ZipError
             ZipError::Io(ref io_err) => {
                 ("Io Error: ".to_string() + (io_err as &error::Error).description()).into()
             },
-            ZipError::InvalidArchive(msg) | ZipError::UnsupportedArchive(msg) => {
+            ZipError::InvalidArchive(msg) | ZipError::UnsupportedArchive(msg) | ZipError::UnsupportedReaderOperation(msg) => {
                 (self.description().to_string() + ": " + msg).into()
             },
             ZipError::FileNotFound => {
@@ -80,6 +83,7 @@ impl error::Error for ZipError
             ZipError::InvalidArchive(..) => "Invalid Zip archive",
             ZipError::UnsupportedArchive(..) => "Unsupported Zip archive",
             ZipError::FileNotFound => "Specified file not found in archive",
+            ZipError::UnsupportedReaderOperation(..) => "Unsupported reader operation",
         }
     }
 

--- a/tests/zip64_large.rs
+++ b/tests/zip64_large.rs
@@ -190,6 +190,7 @@ impl Read for Zip64File {
 
 #[test]
 fn zip64_large() {
+    use zip::read::ZipFileEntry;
     let zipfile = Zip64File::new();
     let mut archive = zip::ZipArchive::new(zipfile).unwrap();
     let mut buf = [0u8; 32];


### PR DESCRIPTION
* note: the PR fixes #14 and contains API break changes
* add trait `ZipFileEntry` that `ZipFile` should implement
* add/modify struct `ZipFile`, `ZipStreamFile` and `ZipFileOwned` for seekable reader, stream reader and reader that cloned.
* add `ZipFile::try_clone` which returns a new `ZipFileOwned`