### PR TITLE
Add ZipFile::header_start

### DIFF
--- a/src/read.rs
+++ b/src/read.rs
@@ -508,6 +508,11 @@ impl<'a> ZipFile<'a> {
     pub fn data_start(&self) -> u64 {
         self.data.data_start
     }
+
+    /// Get the starting offset of the zip header for this file
+    pub fn header_start(&self) -> u64 {
+        self.data.header_start
+    }
 }
 
 impl<'a> Read for ZipFile<'a> {


### PR DESCRIPTION
I need this information for a small project I have been working on. This new function returns the offset of the local file header for a ZipFile object.