### PR TITLE
Add function to extract a all files in an archive to a directory

### DIFF
--- a/src/read.rs
+++ b/src/read.rs
@@ -6,8 +6,8 @@ use crate::result::{ZipError, ZipResult};
 use crate::spec;
 use std::borrow::Cow;
 use std::collections::HashMap;
-use std::io::{self, prelude::*};
 use std::fs;
+use std::io::{self, prelude::*};
 use std::path::Path;
 
 use crate::cp437::FromCp437;

--- a/src/read.rs
+++ b/src/read.rs
@@ -6,8 +6,9 @@ use crate::result::{ZipError, ZipResult};
 use crate::spec;
 use std::borrow::Cow;
 use std::collections::HashMap;
-use std::io;
-use std::io::prelude::*;
+use std::io::{self, prelude::*};
+use std::fs;
+use std::path::Path;
 
 use crate::cp437::FromCp437;
 use crate::types::{DateTime, System, ZipFileData};
@@ -231,6 +232,50 @@ impl<R: Read + io::Seek> ZipArchive<R> {
             offset: archive_offset,
             comment: footer.zip_file_comment,
         })
+    }
+
+    /// Extract a Zip archive into a directory.
+    ///
+    /// Paths are sanitized so that they cannot escape the given directory.
+    ///
+    /// # Platform-specific behaviour
+    ///
+    /// On unix systems permissions from the zip file are preserved, if they exist.
+    pub fn extract(&mut self, directory: &Path) -> ZipResult<()> {
+        for i in 0..self.len() {
+            let mut file = self.by_index(i)?;
+            let filepath = file.sanitized_name();
+
+            // `sanitized_name` should return a relative path
+            // otherwise there's a risk of directory traversal attacks
+            assert!(filepath.is_relative());
+
+            let outpath = directory.join(filepath);
+
+            if (&*file.name()).ends_with('/') {
+                fs::create_dir_all(&outpath)?;
+            } else {
+                if let Some(p) = outpath.parent() {
+                    if !p.exists() {
+                        fs::create_dir_all(&p)?;
+                    }
+                }
+                let mut outfile = fs::File::create(&outpath)?;
+                io::copy(&mut file, &mut outfile)?;
+            }
+
+            // Get and Set permissions
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+
+                if let Some(mode) = file.unix_mode() {
+                    fs::set_permissions(&outpath, fs::Permissions::from_mode(mode))?;
+                }
+            }
+        }
+
+        Ok(())
     }
 
     /// Number of files contained in this zip.

--- a/src/read.rs
+++ b/src/read.rs
@@ -238,6 +238,8 @@ impl<R: Read + io::Seek> ZipArchive<R> {
     ///
     /// Paths are sanitized so that they cannot escape the given directory.
     ///
+    /// This bails on the first error and does not attempt cleanup.
+    ///
     /// # Platform-specific behaviour
     ///
     /// On unix systems permissions from the zip file are preserved, if they exist.

--- a/src/read.rs
+++ b/src/read.rs
@@ -241,18 +241,14 @@ impl<R: Read + io::Seek> ZipArchive<R> {
     /// # Platform-specific behaviour
     ///
     /// On unix systems permissions from the zip file are preserved, if they exist.
-    pub fn extract(&mut self, directory: &Path) -> ZipResult<()> {
+    pub fn extract(&mut self, directory: &dyn AsRef<Path>) -> ZipResult<()> {
         for i in 0..self.len() {
             let mut file = self.by_index(i)?;
             let filepath = file.sanitized_name();
 
-            // `sanitized_name` should return a relative path
-            // otherwise there's a risk of directory traversal attacks
-            assert!(filepath.is_relative());
+            let outpath = directory.as_ref().join(filepath);
 
-            let outpath = directory.join(filepath);
-
-            if (&*file.name()).ends_with('/') {
+            if (file.name()).ends_with('/') {
                 fs::create_dir_all(&outpath)?;
             } else {
                 if let Some(p) = outpath.parent() {

--- a/src/read.rs
+++ b/src/read.rs
@@ -243,7 +243,7 @@ impl<R: Read + io::Seek> ZipArchive<R> {
     /// # Platform-specific behaviour
     ///
     /// On unix systems permissions from the zip file are preserved, if they exist.
-    pub fn extract(&mut self, directory: &dyn AsRef<Path>) -> ZipResult<()> {
+    pub fn extract<P: AsRef<Path>>(&mut self, directory: P) -> ZipResult<()> {
         for i in 0..self.len() {
             let mut file = self.by_index(i)?;
             let filepath = file.sanitized_name();

--- a/tests/extract.rs
+++ b/tests/extract.rs
@@ -1,8 +1,8 @@
 extern crate zip;
 
+use std::fs;
 use std::io;
 use std::path::PathBuf;
-use std::fs;
 
 use zip::ZipArchive;
 
@@ -13,7 +13,9 @@ fn extract() {
     v.extend_from_slice(include_bytes!("../tests/data/files_and_dirs.zip"));
     let mut archive = ZipArchive::new(io::Cursor::new(v)).expect("couldn't open test zip file");
 
-    archive.extract(&PathBuf::from("test_directory")).expect("extract failed");
+    archive
+        .extract(&PathBuf::from("test_directory"))
+        .expect("extract failed");
 
     // Cleanup
     fs::remove_dir_all("test_directory").expect("failed to remove extracted files");

--- a/tests/extract.rs
+++ b/tests/extract.rs
@@ -1,0 +1,20 @@
+extern crate zip;
+
+use std::io;
+use std::path::PathBuf;
+use std::fs;
+
+use zip::ZipArchive;
+
+// This tests extracting the contents of a zip file
+#[test]
+fn extract() {
+    let mut v = Vec::new();
+    v.extend_from_slice(include_bytes!("../tests/data/files_and_dirs.zip"));
+    let mut archive = ZipArchive::new(io::Cursor::new(v)).expect("couldn't open test zip file");
+
+    archive.extract(&PathBuf::from("test_directory")).expect("extract failed");
+
+    // Cleanup
+    fs::remove_dir_all("test_directory").expect("failed to remove extracted files");
+}


### PR DESCRIPTION
Adds a method `extract` to `ZipArchive` to extract all files in an archive to a directory. Based on the [extract example](https://github.com/mvdnes/zip-rs/blob/master/examples/extract.rs).

Fixes https://github.com/mvdnes/zip-rs/issues/62