### PR TITLE
Fix month bounds check in `DateTime::from_time()`

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -333,6 +333,60 @@ mod test {
         assert!(DateTime::from_date_and_time(2107, 12, 32, 0, 0, 0).is_err());
     }
 
+    #[cfg(feature = "time")]
+    #[test]
+    fn datetime_from_time_bounds() {
+        use super::DateTime;
+
+        // 1979-12-31 23:59:59
+        assert!(DateTime::from_time(::time::Tm {
+            tm_sec: 59,
+            tm_min: 59,
+            tm_hour: 23,
+            tm_mday: 31,
+            tm_mon: 11,  // tm_mon has number range [0, 11]
+            tm_year: 79, // 1979 - 1900 = 79
+            ..::time::empty_tm()
+        })
+        .is_err());
+
+        // 1980-01-01 00:00:00
+        assert!(DateTime::from_time(::time::Tm {
+            tm_sec: 0,
+            tm_min: 0,
+            tm_hour: 0,
+            tm_mday: 1,
+            tm_mon: 0,   // tm_mon has number range [0, 11]
+            tm_year: 80, // 1980 - 1900 = 80
+            ..::time::empty_tm()
+        })
+        .is_ok());
+
+        // 2107-12-31 23:59:59
+        assert!(DateTime::from_time(::time::Tm {
+            tm_sec: 59,
+            tm_min: 59,
+            tm_hour: 23,
+            tm_mday: 31,
+            tm_mon: 11,   // tm_mon has number range [0, 11]
+            tm_year: 207, // 2107 - 1900 = 207
+            ..::time::empty_tm()
+        })
+        .is_ok());
+
+        // 2108-01-01 00:00:00
+        assert!(DateTime::from_time(::time::Tm {
+            tm_sec: 0,
+            tm_min: 0,
+            tm_hour: 0,
+            tm_mday: 1,
+            tm_mon: 0,    // tm_mon has number range [0, 11]
+            tm_year: 208, // 2108 - 1900 = 208
+            ..::time::empty_tm()
+        })
+        .is_err());
+    }
+
     #[test]
     fn time_conversion() {
         use super::DateTime;

--- a/src/types.rs
+++ b/src/types.rs
@@ -111,7 +111,7 @@ impl DateTime {
     /// Returns `Err` when this object is out of bounds
     pub fn from_time(tm: ::time::Tm) -> Result<DateTime, ()> {
         if tm.tm_year >= 80 && tm.tm_year <= 207
-            && tm.tm_mon >= 1 && tm.tm_mon <= 31
+            && tm.tm_mon >= 0 && tm.tm_mon <= 11
             && tm.tm_mday >= 1 && tm.tm_mday <= 31
             && tm.tm_hour >= 0 && tm.tm_hour <= 23
             && tm.tm_min >= 0 && tm.tm_min <= 59


### PR DESCRIPTION
The bounds checks for the `tm_mon` field of the `tm` parameter to `DateTime::from_time()` are wrong:
Instead of testing for range [0, 11], they are testing for [1, 31], probably due to a copy-paste error. Thus at the moment, *all otherwise valid dates in the month of January* will `Err` out.

To fix this:
* Fix bounds check of `tm.tm_mon` to [0, 11]
* Add test case to check the correct bounds for ZIP files as constrained by MS-DOS date and time bounds