### PR TITLE
Added ZipArchive::file_names() method to return all the filenames in archive.

### DIFF
--- a/src/read.rs
+++ b/src/read.rs
@@ -256,6 +256,11 @@ impl<R: Read+io::Seek> ZipArchive<R>
         &self.comment
     }
 
+    /// Returns an iterator over all the file and directory names in this archive.
+    pub fn file_names(&self) -> impl Iterator<Item = &str> {
+        self.names_map.keys().map(|s| s.as_str())
+    }
+
     /// Search for a file entry by name
     pub fn by_name<'a>(&'a mut self, name: &str) -> ZipResult<ZipFile<'a>>
     {

--- a/tests/end_to_end.rs
+++ b/tests/end_to_end.rs
@@ -1,6 +1,8 @@
 use std::io::prelude::*;
 use zip::write::FileOptions;
 use std::io::Cursor;
+use std::iter::FromIterator;
+use std::collections::HashSet;
 
 // This test asserts that after creating a zip file, then reading its contents back out,
 // the extracted data will *always* be exactly the same as the original data.
@@ -35,6 +37,11 @@ fn write_to_zip_file(file: &mut Cursor<Vec<u8>>) -> zip::result::ZipResult<()> {
 
 fn read_zip_file(zip_file: &mut Cursor<Vec<u8>>) -> zip::result::ZipResult<String> {
     let mut archive = zip::ZipArchive::new(zip_file).unwrap();
+
+    let expected_file_names = [ "test/", "test/☃.txt", "test/lorem_ipsum.txt" ];
+    let expected_file_names = HashSet::from_iter(expected_file_names.iter().copied());
+    let file_names = archive.file_names().collect::<HashSet<_>>();
+    assert_eq!(file_names, expected_file_names);
 
     let mut file = archive.by_name("test/lorem_ipsum.txt")?;
 


### PR DESCRIPTION
Added ZipArchive::file_names() method to return an iterator of all the file names in the archive.

Using ZipArchive::by_index() to obtain a list of files is slow, if the files are
not read, because it creates the decompressor internally before returning ZipFile.

Fixes #122