### PR TITLE
Add ability to skip CRC checking by feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ rand = "0.4"
 walkdir = "1.0"
 
 [features]
+nocrc = []
 deflate = ["flate2/rust_backend"]
 deflate-miniz = ["flate2/default"]
 deflate-zlib = ["flate2/zlib"]

--- a/src/read.rs
+++ b/src/read.rs
@@ -63,8 +63,10 @@ pub struct ZipArchive<R: Read + io::Seek>
 enum ZipFileReader<'a> {
     NoReader,
     Stored(Crc32Reader<io::Take<&'a mut dyn Read>>),
-    #[cfg(feature = "deflate")]
+    #[cfg(all(feature = "deflate", not(feature = "nocrc")))]
     Deflated(Crc32Reader<flate2::read::DeflateDecoder<io::Take<&'a mut dyn Read>>>),
+    #[cfg(all(feature = "deflate", feature = "nocrc"))]
+    Deflated(flate2::read::DeflateDecoder<io::Take<&'a mut dyn Read>>),
     #[cfg(feature = "bzip2")]
     Bzip2(Crc32Reader<BzDecoder<io::Take<&'a mut dyn Read>>>),
 }
@@ -94,13 +96,19 @@ fn make_reader<'a>(
                 reader,
                 crc32)))
         },
-        #[cfg(feature = "deflate")]
+        #[cfg(all(feature = "deflate", not(feature = "nocrc")))]
         CompressionMethod::Deflated =>
         {
             let deflate_reader = DeflateDecoder::new(reader);
             Ok(ZipFileReader::Deflated(Crc32Reader::new(
                 deflate_reader,
                 crc32)))
+        },
+        #[cfg(all(feature = "deflate", feature = "nocrc"))]
+        CompressionMethod::Deflated =>
+        {
+            let deflate_reader = DeflateDecoder::new(reader);
+            Ok(ZipFileReader::Deflated(deflate_reader))
         },
         #[cfg(feature = "bzip2")]
         CompressionMethod::Bzip2 =>
@@ -538,8 +546,10 @@ impl<'a> Drop for ZipFile<'a> {
             let mut reader = match innerreader {
                 ZipFileReader::NoReader => panic!("ZipFileReader was in an invalid state"),
                 ZipFileReader::Stored(crcreader) => crcreader.into_inner(),
-                #[cfg(feature = "deflate")]
+                #[cfg(all(feature = "deflate", not(feature = "nocrc")))]
                 ZipFileReader::Deflated(crcreader) => crcreader.into_inner().into_inner(),
+                #[cfg(all(feature = "deflate", feature = "nocrc"))]
+                ZipFileReader::Deflated(reader) => reader.into_inner(),
                 #[cfg(feature = "bzip2")]
                 ZipFileReader::Bzip2(crcreader) => crcreader.into_inner().into_inner(),
             };


### PR DESCRIPTION
Not taking this PR too seriously, but until I dive into why allocations within CRC32 checking are slow (#144) this alleviates the problem.  Obviously not ideal, you don't want to open a corrupt zip etc.

This is only intended to be used by the `wasm-unknown-unknown` target, and even then with caveats.