### PR TITLE
Add deprecation warnings to potentially narrow the API

### DIFF
--- a/src/compression.rs
+++ b/src/compression.rs
@@ -34,6 +34,7 @@ impl CompressionMethod {
             8 => CompressionMethod::Deflated,
             #[cfg(feature = "bzip2")]
             12 => CompressionMethod::Bzip2,
+            #[allow(deprecated)]
             v => CompressionMethod::Unsupported(v),
         }
     }
@@ -50,6 +51,7 @@ impl CompressionMethod {
             CompressionMethod::Deflated => 8,
             #[cfg(feature = "bzip2")]
             CompressionMethod::Bzip2 => 12,
+            #[allow(deprecated)]
             CompressionMethod::Unsupported(v) => v,
         }
     }
@@ -69,7 +71,9 @@ mod test {
     #[test]
     fn from_eq_to() {
         for v in 0..(::std::u16::MAX as u32 + 1) {
+            #[allow(deprecated)]
             let from = CompressionMethod::from_u16(v as u16);
+            #[allow(deprecated)]
             let to = from.to_u16() as u32;
             assert_eq!(v, to);
         }
@@ -88,8 +92,11 @@ mod test {
     #[test]
     fn to_eq_from() {
         fn check_match(method: CompressionMethod) {
+            #[allow(deprecated)]
             let to = method.to_u16();
+            #[allow(deprecated)]
             let from = CompressionMethod::from_u16(to);
+            #[allow(deprecated)]
             let back = from.to_u16();
             assert_eq!(to, back);
         }

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -14,11 +14,19 @@ pub enum CompressionMethod {
     #[cfg(feature = "bzip2")]
     Bzip2,
     /// Unsupported compression method
+    #[deprecated(
+        since = "0.5.7",
+        note = "implementation details are being removed from the public API"
+    )]
     Unsupported(u16),
 }
 
 impl CompressionMethod {
     /// Converts an u16 to its corresponding CompressionMethod
+    #[deprecated(
+        since = "0.5.7",
+        note = "implementation details are being removed from the public API"
+    )]
     pub fn from_u16(val: u16) -> CompressionMethod {
         match val {
             0 => CompressionMethod::Stored,
@@ -31,6 +39,10 @@ impl CompressionMethod {
     }
 
     /// Converts a CompressionMethod to a u16
+    #[deprecated(
+        since = "0.5.7",
+        note = "implementation details are being removed from the public API"
+    )]
     pub fn to_u16(self) -> u16 {
         match self {
             CompressionMethod::Stored => 0,

--- a/src/read.rs
+++ b/src/read.rs
@@ -362,7 +362,10 @@ fn central_header_to_zip_file<R: Read + io::Seek>(
         system: System::from_u8((version_made_by >> 8) as u8),
         version_made_by: version_made_by as u8,
         encrypted,
-        compression_method: CompressionMethod::from_u16(compression_method),
+        compression_method: {
+            #[allow(deprecated)]
+            CompressionMethod::from_u16(compression_method)
+        },
         last_modified_time: DateTime::from_msdos(last_mod_date, last_mod_time),
         crc32,
         compressed_size: compressed_size as u64,
@@ -615,6 +618,7 @@ pub fn read_zipfile_from_stream<'a, R: io::Read>(
     let encrypted = flags & 1 == 1;
     let is_utf8 = flags & (1 << 11) != 0;
     let using_data_descriptor = flags & (1 << 3) != 0;
+    #[allow(deprecated)]
     let compression_method = CompressionMethod::from_u16(reader.read_u16::<LittleEndian>()?);
     let last_mod_time = reader.read_u16::<LittleEndian>()?;
     let last_mod_date = reader.read_u16::<LittleEndian>()?;

--- a/src/write.rs
+++ b/src/write.rs
@@ -408,6 +408,7 @@ impl<W: Write + io::Seek> GenericZipWriter<W> {
             CompressionMethod::Bzip2 => {
                 GenericZipWriter::Bzip2(BzEncoder::new(bare, bzip2::Compression::Default))
             }
+            #[allow(deprecated)]
             CompressionMethod::Unsupported(..) => {
                 return Err(ZipError::UnsupportedArchive("Unsupported compression"))
             }
@@ -473,6 +474,7 @@ fn write_local_file_header<T: Write>(writer: &mut T, file: &ZipFileData) -> ZipR
     };
     writer.write_u16::<LittleEndian>(flag)?;
     // Compression method
+    #[allow(deprecated)]
     writer.write_u16::<LittleEndian>(file.compression_method.to_u16())?;
     // last mod file time and last mod file date
     writer.write_u16::<LittleEndian>(file.last_modified_time.timepart())?;
@@ -524,6 +526,7 @@ fn write_central_directory_header<T: Write>(writer: &mut T, file: &ZipFileData) 
     };
     writer.write_u16::<LittleEndian>(flag)?;
     // compression method
+    #[allow(deprecated)]
     writer.write_u16::<LittleEndian>(file.compression_method.to_u16())?;
     // last mod file time + date
     writer.write_u16::<LittleEndian>(file.last_modified_time.timepart())?;


### PR DESCRIPTION
I believe we should attempt to gear the crate towards easily handling ZIP files correctly. There are enough warts introduced by the format itself, and it would be good to keep the API surface simple.

For now, deprecating these items lets users share how they're using them and gives us a chance to consider how to replace them. 

- Related to https://github.com/mvdnes/zip-rs/issues/58#issuecomment-644113649