### PR TITLE
Bump walkdir dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ thiserror = "1.0"
 [dev-dependencies]
 bencher = "0.1"
 rand = "0.7"
-walkdir = "1.0"
+walkdir = "2"
 
 [features]
 deflate = ["flate2/rust_backend"]


### PR DESCRIPTION
Walkdir 2.3.1 is out; the zip crate works fine with the new version:

https://crates.io/crates/walkdir
https://koji.fedoraproject.org/koji/buildinfo?buildID=1534463

Signed-off-by: Michel Alexandre Salim <michel@michel-slm.name>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mvdnes/zip-rs/169)
<!-- Reviewable:end -->
