### PR TITLE
chore: pin the flate2 version for now

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ Library to support the reading and writing of zip files.
 edition = "2018"
 
 [dependencies]
+# FIXME(#170): flate2 1.0.15 has an MSRV of 1.36.0, breaking ours. We'll update when we know if this will be addressed
 flate2 = { version = ">=1.0.0, <=1.0.14", default-features = false, optional = true }
 time = { version = "0.1", optional = true }
 byteorder = "1.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ Library to support the reading and writing of zip files.
 edition = "2018"
 
 [dependencies]
-flate2 = { version = "1.0", default-features = false, optional = true }
+flate2 = { version = ">=1.0.0, <=1.0.14", default-features = false, optional = true }
 time = { version = "0.1", optional = true }
 byteorder = "1.3"
 bzip2 = { version = "0.3", optional = true }


### PR DESCRIPTION
This should fix the build until we have a more permanent solution. 

https://github.com/mvdnes/zip-rs/issues/170#issuecomment-655419242